### PR TITLE
Build simplifications and fixes.

### DIFF
--- a/uros/Kconfig
+++ b/uros/Kconfig
@@ -1,21 +1,21 @@
 # Kconfig for micro-ROS
 
-menu "microROS"
+menu "micro-ROS"
 
 config UROS
-    bool "Enable microROS"
+    bool "Enable micro-ROS"
     default n
     ---help---
-        Enable support for uROS 
+        Enable support for micro-ROS 
 
 if UROS
 
 config UROS_DIR
-    string "microROS workspace (relative to NuttX)"
+    string "micro-ROS workspace (relative to NuttX)"
     default "../uros_ws/"
     ---help---
-	Location of the microROS workspace.
+	Location of the micro-ROS workspace.
 
 endif
 
-endmenu # uROS
+endmenu # UROS

--- a/uros/Makefile
+++ b/uros/Makefile
@@ -21,21 +21,25 @@ else
 	BUILD_TYPE = RelWithDebInfo
 endif
 
-all: .built
+all: colcon_compile $(BIN)
   .PHONY: clean depend distclean preconfig
   .PRECIOUS: ../../libapps$(LIBEXT)
 
-.built: colcon_compile
-	$(call DELDIR, $(UROS_DIR)/build/extracted)
-	$(Q) mkdir $(UROS_DIR)/build/extracted
-	for lib in $(shell find $(UROS_DIR)/install -name '*.a'); do \
-		cd $(UROS_DIR)/build/extracted && \
-		$(ARCROSSDEV)ar -x $$lib && \
-		cd - > /dev/null && \
-		$(ARCROSSDEV)ar q $(BIN) $(UROS_DIR)/build/extracted/* && \
-		rm $(UROS_DIR)/build/extracted/*; \
-	done
-	$(Q) touch .built
+
+%.stamp_archive: %.a
+	#-$(Q) mkdir -p extract/$(*F)
+	-$(Q) mkdir -p extract/temp
+	cd extract/temp && $(ARCROSSDEV)ar -x $<
+	cd extract/temp; for file in *; do mv $$file ../$(*F)_$$file; done
+	touch $@ -r $<
+
+%.stamp_update: %.stamp_archive
+	$(ARCROSSDEV)ar r $(BIN) extract/$(*F)_*
+	touch $@
+
+ARCHIVES = $(shell find $(UROS_DIR)/install -name '*.a')
+
+$(BIN): $(ARCHIVES:.a=.stamp_update)
 
 arm_toolchain.cmake: $(TOPDIR)/.config arm_toolchain.cmake.in
 	cat arm_toolchain.cmake.in | \
@@ -67,6 +71,9 @@ depend: .depend
 
 clean:
 	cd $(UROS_DIR); colcon build --cmake-target clean --cmake-target-skip-unavailable
+	rm -f $(ARCHIVES:.a=.stamp_archive)
+	rm -f $(ARCHIVES:.a=.stamp_update)
+	rm -rf extract
 
 distclean:
 	$(call DELDIR, $(UROS_DIR)/build)

--- a/uros/Makefile
+++ b/uros/Makefile
@@ -37,13 +37,15 @@ all: .built
 	done
 	$(Q) touch .built
 
-colcon_compile: 
+arm_toolchain.cmake: $(TOPDIR)/.config arm_toolchain.cmake.in
 	cat arm_toolchain.cmake.in | \
 		sed "s/@CROSSDEV@/$(CROSSDEV)/g" | \
 		sed "s/@NUTTX_TOPDIR@/$(subst /,\/,$(TOPDIR))/g" |\
 		sed "s/@ARCH_CPU_FLAGS@/\"$(ARCHCPUFLAGS)\"/g" |\
 		sed "s/@ARCH_OPT_FLAGS@/\"$(ARCHOPTIMIZATION)\"/g" \
 		> arm_toolchain.cmake
+
+colcon_compile: arm_toolchain.cmake
 	$(Q) cd $(UROS_DIR); \
 		colcon build \
 			--packages-ignore-regex=.*_cpp \
@@ -57,7 +59,7 @@ colcon_compile:
 
 install: 
 
-context: colcon_compile
+context: arm_toolchain.cmake
 
 .depend:
 

--- a/uros/Makefile
+++ b/uros/Makefile
@@ -64,12 +64,14 @@ context: colcon_compile
 depend: .depend
 
 clean:
+	cd $(UROS_DIR); colcon build --cmake-target clean --cmake-target-skip-unavailable
+
+distclean:
 	$(call DELDIR, $(UROS_DIR)/build)
 	$(call DELDIR, $(UROS_DIR)/install)
 	$(call DELDIR, $(UROS_DIR)/log)
 	$(call DELFILE, $(UROS_DIR)/.built)
 
-distclean: clean
 
 preconfig:
 


### PR DESCRIPTION
This makes the build more efficient, by only doing what's necessary 
when compiling the ROS2 workspace and copying the object files.
